### PR TITLE
run "rm -rf" as sudo

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -10,4 +10,4 @@ docker system prune -af --volumes || true
 
 echo "cleaning up working directory..."
 shopt -s dotglob
-rm -rf *
+sudo rm -rf *


### PR DESCRIPTION
Currently the cleanup fails if the `_work` folder contains bind-mounted directories which contain files owned by users with a uid other than `1000`

I enabled passwordless sudo on the runners, which is not optimal security wise, but since the `runner` user is already in the `docker` group and thus effectively root as well, that should not really matter